### PR TITLE
CharacterCreate Bug Fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "DatabaseManagerSourceExtensions"]
+	path = DatabaseManagerSourceExtensions
+	url = https://github.com/CallepoGaming/DatabaseManagerSourceExtensions.git

--- a/DatabaseManagerSourceExtensions.meta
+++ b/DatabaseManagerSourceExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee9f52dc8b3c0e2409389c9fc2d32735
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SQLite/SQLiteDatabase_Character.cs
+++ b/SQLite/SQLiteDatabase_Character.cs
@@ -338,7 +338,7 @@ namespace MultiplayerARPG.MMO
             SqliteTransaction transaction = _connection.BeginTransaction();
             try
             {
-                ExecuteNonQuery("INSERT INTO characters " +
+                ExecuteNonQuery(transaction, "INSERT INTO characters " +
                     "(id, userId, dataId, entityId, factionId, characterName, level, exp, currentHp, currentMp, currentStamina, currentFood, currentWater, equipWeaponSet, statPoint, skillPoint, gold, currentMapName, currentPositionX, currentPositionY, currentPositionZ, currentRotationX, currentRotationY, currentRotationZ, respawnMapName, respawnPositionX, respawnPositionY, respawnPositionZ, mountDataId, iconDataId, frameDataId, titleDataId) VALUES " +
                     "(@id, @userId, @dataId, @entityId, @factionId, @characterName, @level, @exp, @currentHp, @currentMp, @currentStamina, @currentFood, @currentWater, @equipWeaponSet, @statPoint, @skillPoint, @gold, @currentMapName, @currentPositionX, @currentPositionY, @currentPositionZ, @currentRotationX, @currentRotationY, @currentRotationZ, @respawnMapName, @respawnPositionX, @respawnPositionY, @respawnPositionZ, @mountDataId, @iconDataId, @frameDataId, @titleDataId)",
                     new SqliteParameter("@id", character.Id),


### PR DESCRIPTION
Character creation with sqlite is bugged.
This fixes it.

Error msg was this 
"ExecuteNonQuery requires the command to have a transaction when the connection assigned to the command is in a pending local transaction. The Transaction property of the command has not been initialized."

dont pull the module change, its only for my fork. but idk how to not include it in the pull request